### PR TITLE
New helper functions, and other small changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,6 +517,33 @@ mod tests {
     }
 
     #[test]
+    fn test_complex_parse_moves() {
+        assert_eq!(
+            // parse_moves("1. d4 Nf6 2. Bf4 Nc6 3. e3 d5 4. Nf3 Bf5 5. Nbd2 e6 6. c3 Bd6 7. Bg5 h6 8. Bh4 g5 9. Bg3 Ne4 10. Nxe4 Bxe4").unwrap(),
+            parse_moves("1. d4 Nf6 2. Bf4 Nc6 3. e3 d5 4. Nf3 Bf5 5. Nbd2 e6 6. c3 Bd6 7. Bg5 h6").unwrap(),
+            MoveSequence {
+                comment: None,
+                moves: vec![
+                    Move::new(Pawn, D4).no_mark().numbered(Some(White(1))),
+                    Move::new(Knight, F6).no_mark().numbered(None),
+                    Move::new(Bishop, F4).no_mark().numbered(Some(White(2))),
+                    Move::new(Knight, C6).no_mark().numbered(None),
+                    Move::new(Pawn, E3).no_mark().numbered(Some(White(3))),
+                    Move::new(Pawn, D5).no_mark().numbered(None),
+                    Move::new(Knight, F3).no_mark().numbered(Some(White(4))),
+                    Move::new(Bishop, F5).no_mark().numbered(None),
+                    Move::new(Knight, D2).from(BX).no_mark().numbered(Some(White(5))),
+                    Move::new(Pawn, E6).no_mark().numbered(None),
+                    Move::new(Pawn, C3).no_mark().numbered(Some(White(6))),
+                    Move::new(Bishop, D6).no_mark().numbered(None),
+                    Move::new(Bishop, G5).no_mark().numbered(Some(White(7))),
+                    Move::new(Pawn, H6).no_mark().numbered(None),
+                ]
+            }
+        );
+    }
+
+    #[test]
     fn test_game_move_with_variations() {
         assert_eq!(
             run(game_move, "4. Bc4 (4. Bb5)"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,10 @@ pub fn read_games(input: &str) -> Result<Vec<Game>, ParseError> {
     Ok(games)
 }
 
+pub fn parse_moves(input: &str) -> Result<MoveSequence, ParseError> {
+    move_sequence(input).map(|r|r.0)
+}
+
 rule!(pgn_string_char:char =
       ["\\\""] => { '\"' } /
       ["\\\\"] => { '\\' } /
@@ -277,7 +281,7 @@ mod tests {
     use super::{pgn_integer, pgn_string, pgn_symbol, read_one_or_more, tag_pair, tag_section,
                 whitespace, game_termination, move_number, move_disambiguation, file, rank, piece,
                 square, basic_move, marked_move, nag, line_end, inline_comment, block_comment,
-                game_move, move_sequence, game, read_games};
+                game_move, move_sequence, game, read_games, parse_moves};
 
     use model::{Move, MoveNumber, MoveSequence, NAG};
     use model::File::*;
@@ -494,6 +498,20 @@ mod tests {
                     CastleKingside.no_mark().numbered(Some(White(10))),
                     CastleQueenside.no_mark().numbered(None),
                 ],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_moves() {
+        assert_eq!(
+            parse_moves("1. e4 c5").unwrap(),
+            MoveSequence {
+                comment: None,
+                moves: vec![
+                    Move::new(Pawn, E4).no_mark().numbered(Some(White(1))),
+                    Move::new(Pawn, C5).no_mark().numbered(None),
+                ]
             }
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub fn read_games(input: &str) -> Result<Vec<Game>, ParseError> {
     Ok(games)
 }
 
-pub fn parse_moves(input: &str) -> Result<MoveSequence, ParseError> {
+pub fn parse_move_sequence(input: &str) -> Result<MoveSequence, ParseError> {
     move_sequence(input).map(|r|r.0)
 }
 
@@ -281,7 +281,7 @@ mod tests {
     use super::{pgn_integer, pgn_string, pgn_symbol, read_one_or_more, tag_pair, tag_section,
                 whitespace, game_termination, move_number, move_disambiguation, file, rank, piece,
                 square, basic_move, marked_move, nag, line_end, inline_comment, block_comment,
-                game_move, move_sequence, game, read_games, parse_moves};
+                game_move, move_sequence, game, read_games};
 
     use model::{Move, MoveNumber, MoveSequence, NAG};
     use model::File::*;
@@ -498,47 +498,6 @@ mod tests {
                     CastleKingside.no_mark().numbered(Some(White(10))),
                     CastleQueenside.no_mark().numbered(None),
                 ],
-            }
-        );
-    }
-
-    #[test]
-    fn test_parse_moves() {
-        assert_eq!(
-            parse_moves("1. e4 c5").unwrap(),
-            MoveSequence {
-                comment: None,
-                moves: vec![
-                    Move::new(Pawn, E4).no_mark().numbered(Some(White(1))),
-                    Move::new(Pawn, C5).no_mark().numbered(None),
-                ]
-            }
-        );
-    }
-
-    #[test]
-    fn test_complex_parse_moves() {
-        assert_eq!(
-            // parse_moves("1. d4 Nf6 2. Bf4 Nc6 3. e3 d5 4. Nf3 Bf5 5. Nbd2 e6 6. c3 Bd6 7. Bg5 h6 8. Bh4 g5 9. Bg3 Ne4 10. Nxe4 Bxe4").unwrap(),
-            parse_moves("1. d4 Nf6 2. Bf4 Nc6 3. e3 d5 4. Nf3 Bf5 5. Nbd2 e6 6. c3 Bd6 7. Bg5 h6").unwrap(),
-            MoveSequence {
-                comment: None,
-                moves: vec![
-                    Move::new(Pawn, D4).no_mark().numbered(Some(White(1))),
-                    Move::new(Knight, F6).no_mark().numbered(None),
-                    Move::new(Bishop, F4).no_mark().numbered(Some(White(2))),
-                    Move::new(Knight, C6).no_mark().numbered(None),
-                    Move::new(Pawn, E3).no_mark().numbered(Some(White(3))),
-                    Move::new(Pawn, D5).no_mark().numbered(None),
-                    Move::new(Knight, F3).no_mark().numbered(Some(White(4))),
-                    Move::new(Bishop, F5).no_mark().numbered(None),
-                    Move::new(Knight, D2).from(BX).no_mark().numbered(Some(White(5))),
-                    Move::new(Pawn, E6).no_mark().numbered(None),
-                    Move::new(Pawn, C3).no_mark().numbered(Some(White(6))),
-                    Move::new(Bishop, D6).no_mark().numbered(None),
-                    Move::new(Bishop, G5).no_mark().numbered(Some(White(7))),
-                    Move::new(Pawn, H6).no_mark().numbered(None),
-                ]
             }
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate peggler;
+pub extern crate peggler;
 
 #[macro_use]
 extern crate enum_primitive;

--- a/src/model.rs
+++ b/src/model.rs
@@ -31,7 +31,7 @@ enum_from_primitive! {
 enum_from_primitive! {
     //Unknowns are represented as X
     //e.g BX means B file and unknown rank
-    #[derive(PartialEq, Eq, Debug, Clone)]
+    #[derive(PartialEq, Eq, Debug, Clone, Hash)]
     pub enum Square {
         A1, A2, A3, A4, A5, A6, A7, A8, AX,
         B1, B2, B3, B4, B5, B6, B7, B8, BX,

--- a/src/model.rs
+++ b/src/model.rs
@@ -76,19 +76,6 @@ impl Square {
         Square::from_u32(9 * file + rank).unwrap()
     }
 
-    fn new_with_name(name: &str) -> Square {
-        if name.chars().count() != 2 {
-            panic!("Square name should have 2 characters")
-        }
-
-        let file_char_value = name.chars().nth(0).unwrap() as u32;
-        let base_char_value = 'a' as u32;
-        let file = file_char_value - base_char_value;
-        assert!(file < 9);
-        let rank = name.chars().nth(1).unwrap().to_digit(10).unwrap() as u32 - 1;
-        Square::new_u32(file, rank)
-    }
-
     pub fn new_with_offset(&self, file_offset: i32, rank_offset: i32) -> Option<Square> {
         if let Some(file) = self.file_with_offset(file_offset) {
             if let Some(rank) = self.rank_with_offset(rank_offset) {
@@ -431,14 +418,6 @@ mod tests {
     #[test]
     fn square_rank_unknown() {
         assert_eq!(HX.rank(), None);
-    }
-
-    #[test]
-    fn square_new_with_name() {
-        assert_eq!(Square::new(Some(A), Some(R1)), Square::new_with_name("a1"));
-        assert_eq!(Square::new(Some(A), Some(R8)), Square::new_with_name("a8"));
-        assert_eq!(Square::new(Some(H), Some(R8)), Square::new_with_name("h8"));
-        assert_eq!(Square::new(Some(H), Some(R1)), Square::new_with_name("h1"));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -127,6 +127,14 @@ impl Square {
     pub fn rank(&self) -> Option<Rank> {
         Rank::from_u32(self.clone() as u32 % 9)
     }
+
+    pub fn get_known(&self) -> Option<Self> {
+        if self.rank().is_some() && self.file().is_some() {
+            Some(self.clone())
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -76,11 +76,55 @@ impl Square {
         Square::from_u32(9 * file + rank).unwrap()
     }
 
-    pub fn file(self: &Square) -> Option<File> {
+    fn new_with_name(name: &str) -> Square {
+        if name.chars().count() != 2 {
+            panic!("Square name should have 2 characters")
+        }
+
+        let file_char_value = name.chars().nth(0).unwrap() as u32;
+        let base_char_value = 'a' as u32;
+        let file = file_char_value - base_char_value;
+        assert!(file < 9);
+        let rank = name.chars().nth(1).unwrap().to_digit(10).unwrap() as u32 - 1;
+        Square::new_u32(file, rank)
+    }
+
+    pub fn new_with_offset(&self, file_offset: i32, rank_offset: i32) -> Option<Square> {
+        if let Some(file) = self.file_with_offset(file_offset) {
+            if let Some(rank) = self.rank_with_offset(rank_offset) {
+                return Some(Self::new_known(file, rank));
+            }
+        }
+        None
+    }
+
+    pub fn file(&self) -> Option<File> {
         File::from_u32(self.clone() as u32 / 9)
     }
 
-    pub fn rank(self: &Square) -> Option<Rank> {
+    fn file_with_offset(&self, offset: i32) -> Option<File> {
+        let new_offset = 9 * offset + self.clone() as i32;
+        if let Some(square) = Square::from_u32(new_offset as u32) {
+            return square.file();
+        }
+        None        
+    }
+
+    fn rank_with_offset(&self, offset: i32) -> Option<Rank> {
+        if let Some(curr_file) = self.file() {
+            let new_offset = offset + self.clone() as i32;
+            if let Some(new_square) = Square::from_u32(new_offset as u32) {
+                if let Some(new_file) = new_square.file() {
+                    if new_file == curr_file {
+                        return new_square.rank();
+                    } 
+                }
+            }
+        }
+        None 
+    }
+
+    pub fn rank(&self) -> Option<Rank> {
         Rank::from_u32(self.clone() as u32 % 9)
     }
 }
@@ -381,6 +425,45 @@ mod tests {
         assert_eq!(HX.rank(), None);
     }
 
+    #[test]
+    fn square_new_with_name() {
+        assert_eq!(Square::new(Some(A), Some(R1)), Square::new_with_name("a1"));
+        assert_eq!(Square::new(Some(A), Some(R8)), Square::new_with_name("a8"));
+        assert_eq!(Square::new(Some(H), Some(R8)), Square::new_with_name("h8"));
+        assert_eq!(Square::new(Some(H), Some(R1)), Square::new_with_name("h1"));
+    }
+
+    #[test]
+    fn square_new_with_offset() {
+        let square = Square::new(Some(B), Some(R2));
+        assert_eq!(Square::new(Some(B), Some(R3)), square.new_with_offset(0, 1).unwrap());
+        assert_eq!(Square::new(Some(C), Some(R2)), square.new_with_offset(1, 0).unwrap());
+        assert_eq!(Square::new(Some(B), Some(R1)), square.new_with_offset(0, -1).unwrap());
+        assert_eq!(Square::new(Some(A), Some(R2)), square.new_with_offset(-1, 0).unwrap());
+
+        assert!(square.new_with_offset(-2, 0).is_none());
+        assert!(square.new_with_offset(7, 0).is_none());
+        assert!(square.new_with_offset(0, -2).is_none());
+        assert!(square.new_with_offset(0, 7).is_none());
+    }
+
+    #[test]
+    fn square_file_with_offset() {
+        let square = Square::new(Some(B), Some(R2));
+        assert_eq!(C, square.file_with_offset(1).unwrap());
+        assert_eq!(A, square.file_with_offset(-1).unwrap());
+        assert!(square.file_with_offset(-2).is_none());
+        assert!(square.file_with_offset(7).is_none());
+    }
+
+    #[test]
+    fn square_rank_with_offset() {
+        let square = Square::new(Some(B), Some(R2));
+        assert_eq!(R3, square.rank_with_offset(1).unwrap());
+        assert_eq!(R1, square.rank_with_offset(-1).unwrap());
+        assert!(square.rank_with_offset(-2).is_none());
+        assert!(square.rank_with_offset(7).is_none());
+    }
 
     #[test]
     fn move_new() {


### PR DESCRIPTION
These are some of the minor changes I needed when working on my project (WIP) https://github.com/mherrerarendon/chess_move_validator
I figure they might be useful for others too.

- Created a new Square method `new_with_offset` that allows you to create a new Square with horizontal and/or vertical offsets relative from the self Square
- Created a new Square method `get_known` that returns an Option<Square> with Some if Square is known
- Make the peggler dependency public (needed for ParseResult)
- Add a new public method that parses only the move sequence string

I'm happy to receive feedback too!